### PR TITLE
Add rules to ignore settings files for the jpa buddy plug-in in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 ### Querydsl ###
 /src/main/generated
 
+### JPA Buddy ###
+.jpb/
+
 ### Eclipse ###
 .metadata
 bin/


### PR DESCRIPTION
intellig plugin 중 jpa 작업을 편하게 해주는 jpa buddy 라는 플러그인으로 인해 자동 생성되는 설정 파일이 
프로젝트에 포함되지 않도록 파일 무시 규칙을 추가함